### PR TITLE
test: fix tests and lock the da version

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -23,7 +23,7 @@ locals {
 module "key_protect_all_inclusive" {
   count                     = local.enable_kms_encryption ? 1 : 0
   source                    = "terraform-ibm-modules/kms-all-inclusive/ibm"
-  version                   = "4.19.5"
+  version                   = "4.19.8"
   resource_group_id         = module.resource_group.resource_group_id
   region                    = var.region
   key_protect_instance_name = "${var.prefix}-kp"

--- a/solutions/standard/main.tf
+++ b/solutions/standard/main.tf
@@ -39,7 +39,7 @@ module "existing_kms_crn_parser" {
 module "kms" {
   count                       = var.enable_kms_encryption && var.existing_kms_instance_crn != null ? 1 : 0 # no need to create any KMS resources if passing an existing key
   source                      = "terraform-ibm-modules/kms-all-inclusive/ibm"
-  version                     = "4.19.5"
+  version                     = "4.19.8"
   create_key_protect_instance = false
   region                      = local.kms_region
   existing_kms_instance_crn   = var.existing_kms_instance_crn

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,13 +1,13 @@
 module github.com/terraform-ibm-modules/terraform-ibm-watsonx-data
 
-go 1.22.4
+go 1.23.0
 
 toolchain go1.24.0
 
 require (
 	github.com/gruntwork-io/terratest v0.48.2
 	github.com/stretchr/testify v1.10.0
-	github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper v1.46.1
+	github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper v1.46.2
 )
 
 require (
@@ -51,7 +51,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.19.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -88,7 +88,7 @@ require (
 	go.opentelemetry.io/otel v1.29.0 // indirect
 	go.opentelemetry.io/otel/metric v1.29.0 // indirect
 	go.opentelemetry.io/otel/trace v1.29.0 // indirect
-	golang.org/x/crypto v0.33.0 // indirect
+	golang.org/x/crypto v0.34.0 // indirect
 	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -139,8 +139,9 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -294,8 +295,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper v1.46.1 h1:D39+Gx0Z6cK6xpAYPizqvY5553A1kGFLqyUDPbkl+wg=
-github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper v1.46.1/go.mod h1:so5NVbOWjrhmaHLHFGksFVqbdzTJb2zgVrk9gQ18Odk=
+github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper v1.46.2 h1:QE9D4+25lbPTEB17lSuOg+W42pbEUqSKGN9fvVqGuF8=
+github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper v1.46.2/go.mod h1:NKAZa5bOPR5ze3appDSN5RCJF3qIDwsBwaPY59ReVuk=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmccombs/hcl2json v0.6.4 h1:/FWnzS9JCuyZ4MNwrG4vMrFrzRgsWEOVi+1AyYUVLGw=
 github.com/tmccombs/hcl2json v0.6.4/go.mod h1:+ppKlIW3H5nsAsZddXPy2iMyvld3SHxyjswOZhavRDk=
@@ -340,8 +341,8 @@ golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98y
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
-golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
-golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
+golang.org/x/crypto v0.34.0 h1:+/C6tk6rf/+t5DhUketUbD1aNGqiSX3j15Z6xuIDlBA=
+golang.org/x/crypto v0.34.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/tests/kp-instance/main.tf
+++ b/tests/kp-instance/main.tf
@@ -7,7 +7,7 @@ module "resource_group" {
 
 module "kms" {
   source                      = "terraform-ibm-modules/kms-all-inclusive/ibm"
-  version                     = "4.19.5"
+  version                     = "4.19.8"
   create_key_protect_instance = true
   key_protect_instance_name   = "${var.prefix}-kp"
   resource_group_id           = module.resource_group.resource_group_id

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -108,7 +108,9 @@ func cleanupResources(t *testing.T, terraformOptions *terraform.Options, prefix 
 	} else {
 		logger.Log(t, "START: Destroy (existing resources)")
 		terraform.Destroy(t, terraformOptions)
-		terraform.WorkspaceDelete(t, terraformOptions, prefix)
+		if prefix != "" {
+			terraform.WorkspaceDelete(t, terraformOptions, prefix)
+		}
 		logger.Log(t, "END: Destroy (existing resources)")
 	}
 }
@@ -179,7 +181,7 @@ func TestRunExistingResourcesExample(t *testing.T) {
 			assert.NotNil(t, output, "Expected some output")
 		}
 	}
-	cleanupResources(t, existingTerraformOptions)
+	cleanupResources(t, existingTerraformOptions, "")
 }
 
 func TestRunStandardSolution(t *testing.T) {

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -72,6 +72,47 @@ func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptio
 	return options
 }
 
+// Provision KMS - Key Protect to use in DA tests
+func setupKMSKeyProtect(t *testing.T, region string) *terraform.Options {
+	prefix := "wxd-da-key"
+	realTerraformDir := "./kp-instance"
+	tempTerraformDir, _ := files.CopyTerraformFolderToTemp(realTerraformDir, fmt.Sprintf(prefix+"-%s", strings.ToLower(random.UniqueId())))
+
+	checkVariable := "TF_VAR_ibmcloud_api_key"
+	val, present := os.LookupEnv(checkVariable)
+	require.True(t, present, checkVariable+" environment variable not set")
+	require.NotEqual(t, "", val, checkVariable+" environment variable is empty")
+
+	logger.Log(t, "Tempdir: ", tempTerraformDir)
+	existingTerraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: tempTerraformDir,
+		Vars: map[string]interface{}{
+			"prefix": prefix,
+			"region": region,
+		},
+		Upgrade: true,
+	})
+
+	terraform.WorkspaceSelectOrNew(t, existingTerraformOptions, prefix)
+	_, existErr := terraform.InitAndApplyE(t, existingTerraformOptions)
+	require.NoError(t, existErr, "Init and Apply of temp resources (KP Instance and Key creation) failed")
+
+	return existingTerraformOptions
+}
+
+func cleanupResources(t *testing.T, terraformOptions *terraform.Options) {
+	// Check if "DO_NOT_DESTROY_ON_FAILURE" is set
+	envVal, _ := os.LookupEnv("DO_NOT_DESTROY_ON_FAILURE")
+	// Destroy the temporary existing resources if required
+	if t.Failed() && strings.ToLower(envVal) == "true" {
+		fmt.Println("Terratest failed. Debug the test and delete resources manually.")
+	} else {
+		logger.Log(t, "START: Destroy (existing resources)")
+		terraform.Destroy(t, terraformOptions)
+		logger.Log(t, "END: Destroy (existing resources)")
+	}
+}
+
 func TestRunBasicExample(t *testing.T) {
 	t.Parallel()
 
@@ -138,111 +179,56 @@ func TestRunExistingResourcesExample(t *testing.T) {
 			assert.NotNil(t, output, "Expected some output")
 		}
 	}
-
-	// Check if "DO_NOT_DESTROY_ON_FAILURE" is set
-	envVal, _ := os.LookupEnv("DO_NOT_DESTROY_ON_FAILURE")
-	// Destroy the temporary existing resources if required
-	if t.Failed() && strings.ToLower(envVal) == "true" {
-		fmt.Println("Terratest failed. Debug the test and delete resources manually.")
-	} else {
-		logger.Log(t, "START: Destroy (existing resources)")
-		terraform.Destroy(t, existingTerraformOptions)
-		terraform.WorkspaceDelete(t, existingTerraformOptions, prefix)
-		logger.Log(t, "END: Destroy (existing resources)")
-	}
+	cleanupResources(t, existingTerraformOptions)
 }
 
-// Test the DA
 func TestRunStandardSolution(t *testing.T) {
 	t.Parallel()
-
-	// ---------------------------------------------------------
-	// Provision KMS - Key Protect
-	// ---------------------------------------------------------
-
 	var region = validRegions[rand.Intn(len(validRegions))]
-
-	prefix := "wx-da"
-	realTerraformDir := "./kp-instance"
-	tempTerraformDir, _ := files.CopyTerraformFolderToTemp(realTerraformDir, fmt.Sprintf(prefix+"-%s", strings.ToLower(random.UniqueId())))
-
-	// Verify ibmcloud_api_key variable is set
-	checkVariable := "TF_VAR_ibmcloud_api_key"
-	val, present := os.LookupEnv(checkVariable)
-	require.True(t, present, checkVariable+" environment variable not set")
-	require.NotEqual(t, "", val, checkVariable+" environment variable is empty")
-
-	logger.Log(t, "Tempdir: ", tempTerraformDir)
-	existingTerraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: tempTerraformDir,
-		Vars: map[string]interface{}{
-			"prefix": prefix,
-			"region": region,
-		},
-		// Set Upgrade to true to ensure latest version of providers and modules are used by terratest.
-		// This is the same as setting the -upgrade=true flag with terraform.
-		Upgrade: true,
-	})
-
-	terraform.WorkspaceSelectOrNew(t, existingTerraformOptions, prefix)
-	_, existErr := terraform.InitAndApplyE(t, existingTerraformOptions)
-
-	if existErr != nil {
-		assert.True(t, existErr == nil, "Init and Apply of temp resources (KP Instance and Key creation) failed")
-	} else {
-		// ------------------------------------------------------------------------------------
-		// Deploy watsonx.data DA using existing KP details
-		// ------------------------------------------------------------------------------------
-
-		options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
-			Testing:       t,
-			TerraformDir:  standardSolutionTerraformDir,
-			Prefix:        "wxd-da",
-			Region:        region,
-			ResourceGroup: resourceGroup,
-		})
-		options.TerraformVars = map[string]interface{}{
-			"prefix":                      options.Prefix,
-			"region":                      options.Region,
-			"use_existing_resource_group": true,
-			"resource_group_name":         terraform.Output(t, existingTerraformOptions, "resource_group_name"),
-			"provider_visibility":         "public",
-			"existing_kms_instance_crn":   terraform.Output(t, existingTerraformOptions, "key_protect_crn"),
-		}
-
-		output, err := options.RunTestConsistency()
-		assert.Nil(t, err, "This should not have errored")
-		assert.NotNil(t, output, "Expected some output")
-	}
-
-	envVal, _ := os.LookupEnv("DO_NOT_DESTROY_ON_FAILURE")
-	// Destroy the temporary resources created
-	if t.Failed() && strings.ToLower(envVal) == "true" {
-		fmt.Println("Terratest failed. Debug the test and delete resources manually.")
-	} else {
-		logger.Log(t, "START: Destroy (existing resources)")
-		terraform.Destroy(t, existingTerraformOptions)
-		logger.Log(t, "END: Destroy (existing resources)")
-	}
-}
-
-func TestRunStandardUpgradeSolution(t *testing.T) {
-	t.Parallel()
+	existingTerraformOptions := setupKMSKeyProtect(t, region)
 
 	options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
 		Testing:       t,
 		TerraformDir:  standardSolutionTerraformDir,
-		Region:        validRegions[rand.Intn(len(validRegions))],
-		Prefix:        "wxa-da-upg",
+		Prefix:        "wxd-da",
+		Region:        region,
 		ResourceGroup: resourceGroup,
 	})
 	options.TerraformVars = map[string]interface{}{
 		"prefix":                      options.Prefix,
 		"region":                      options.Region,
 		"use_existing_resource_group": true,
-		"resource_group_name":         options.Prefix,
+		"resource_group_name":         terraform.Output(t, existingTerraformOptions, "resource_group_name"),
 		"provider_visibility":         "public",
-		"existing_kms_instance_crn":   permanentResources["hpcs_south_crn"],
+		"existing_kms_instance_crn":   terraform.Output(t, existingTerraformOptions, "key_protect_crn"),
+	}
+
+	output, err := options.RunTestConsistency()
+	assert.Nil(t, err, "This should not have errored")
+	assert.NotNil(t, output, "Expected some output")
+
+	cleanupResources(t, existingTerraformOptions)
+}
+
+func TestRunStandardUpgradeSolution(t *testing.T) {
+	t.Parallel()
+	var region = validRegions[rand.Intn(len(validRegions))]
+	existingTerraformOptions := setupKMSKeyProtect(t, region)
+
+	options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
+		Testing:       t,
+		TerraformDir:  standardSolutionTerraformDir,
+		Prefix:        "wxd-da-upg",
+		Region:        region,
+		ResourceGroup: resourceGroup,
+	})
+	options.TerraformVars = map[string]interface{}{
+		"prefix":                      options.Prefix,
+		"region":                      options.Region,
+		"use_existing_resource_group": true,
+		"resource_group_name":         terraform.Output(t, existingTerraformOptions, "resource_group_name"),
+		"provider_visibility":         "public",
+		"existing_kms_instance_crn":   terraform.Output(t, existingTerraformOptions, "key_protect_crn"),
 	}
 
 	output, err := options.RunTestUpgrade()
@@ -250,4 +236,6 @@ func TestRunStandardUpgradeSolution(t *testing.T) {
 		assert.Nil(t, err, "This should not have errored")
 		assert.NotNil(t, output, "Expected some output")
 	}
+
+	cleanupResources(t, existingTerraformOptions)
 }


### PR DESCRIPTION
### Description


 - This PR modifies the prefixes used in tests and locks the DA to 1.75.2 provider version
 - Make use of only one upgrade test i.e. DA upgrade test
- Bumped the git submodule so it uses latest golang linter since the CI image is on go 1.24

Issue addressed - [12716](https://github.ibm.com/GoldenEye/issues/issues/12716)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
