### PR TITLE
fix: update validation order

### DIFF
--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -90,6 +90,11 @@ variable "enable_kms_encryption" {
   default     = false
 
   validation {
+    condition     = !var.enable_kms_encryption || (var.region != "au-syd" && var.region != "ca-tor")
+    error_message = "Key management service encryption is supported only when the configured plan is 'Enterprise (lakehouse-enterprise)' and the deployment region is not 'au-syd' and 'ca-tor'."
+  }
+
+  validation {
     condition     = var.enable_kms_encryption ? (var.existing_kms_instance_crn != null || var.existing_kms_key_crn != null) : true
     error_message = "When 'enable_kms_encryption' is true, you must provide either 'existing_kms_instance_crn' or 'existing_kms_key_crn'."
   }

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -90,7 +90,7 @@ variable "enable_kms_encryption" {
   default     = false
 
   validation {
-    condition     = !var.enable_kms_encryption || (var.region != "au-syd" && var.region != "ca-tor")
+    condition     = !var.enable_kms_encryption || (var.region != "au-syd" && var.region != "ca-tor" && var.service_plan == "lakehouse-enterprise")
     error_message = "Key management service encryption is supported only when the configured plan is 'Enterprise (lakehouse-enterprise)' and the deployment region is not 'au-syd' and 'ca-tor'."
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -57,10 +57,9 @@ variable "plan" {
   validation {
     condition = anytrue([
       var.plan == "lite" && contains(["us-south", "eu-de", "jp-tok"], var.region),
-      var.plan == "lakehouse-enterprise" && contains(["us-south", "eu-de", "eu-gb", "jp-tok", "us-east", "au-syd", "ca-tor"], var.region),
-      var.plan == "lakehouse-enterprise-mcsp" && contains(["au-syd", "ca-tor"], var.region)
+      var.plan == "lakehouse-enterprise" && contains(["us-south", "eu-de", "eu-gb", "jp-tok", "us-east", "au-syd", "ca-tor"], var.region)
     ])
-    error_message = "Possible plan and region combinations are: `lite` (eu-de, jp-tok, us-south), `lakehouse-enterprise` (eu-de, eu-gb, jp-tok, us-south, us-east, au-syd, ca-tor), `lakehouse-enterprise-mcsp` (only in au-syd, ca-tor)."
+    error_message = "Possible plan and region combinations are: `lite` (eu-de, jp-tok, us-south), `lakehouse-enterprise` (eu-de, eu-gb, jp-tok, us-south, us-east), `lakehouse-enterprise-mcsp` (only in au-syd, ca-tor)."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -57,9 +57,10 @@ variable "plan" {
   validation {
     condition = anytrue([
       var.plan == "lite" && contains(["us-south", "eu-de", "jp-tok"], var.region),
-      var.plan == "lakehouse-enterprise" && contains(["us-south", "eu-de", "eu-gb", "jp-tok", "us-east", "au-syd", "ca-tor"], var.region)
+      var.plan == "lakehouse-enterprise" && contains(["us-south", "eu-de", "eu-gb", "jp-tok", "us-east", "au-syd", "ca-tor"], var.region),
+      var.plan == "lakehouse-enterprise-mcsp" && contains(["au-syd", "ca-tor"], var.region)
     ])
-    error_message = "Possible plan and region combinations are: `lite` (eu-de, jp-tok, us-south), `lakehouse-enterprise` (eu-de, eu-gb, jp-tok, us-south, us-east), `lakehouse-enterprise-mcsp` (only in au-syd, ca-tor)."
+    error_message = "Possible plan and region combinations are: `lite` (eu-de, jp-tok, us-south), `lakehouse-enterprise` (eu-de, eu-gb, jp-tok, us-south, us-east, au-syd, ca-tor), `lakehouse-enterprise-mcsp` (only in au-syd, ca-tor)."
   }
 }
 


### PR DESCRIPTION
### Description

Fixes https://github.com/terraform-ibm-modules/terraform-ibm-watsonx-data/issues/233

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

If the user is trying to put `enable_kms_encryption = true` for regions `au-syd` and `ca-tor`, the error message `Key management service encryption is supported only when the configured plan is 'Enterprise (lakehouse-enterprise)' and the deployment region is not 'au-syd' and 'ca-tor'` will be thrown in the very first step.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
